### PR TITLE
ジャンルの不要なスペースを削除

### DIFF
--- a/app/javascript/packs/components/ChannelPlayer.tsx
+++ b/app/javascript/packs/components/ChannelPlayer.tsx
@@ -29,7 +29,7 @@ const ChannelPlayer = (props: Props) => {
     )
   const index = channels.findIndex(item => item === channel)
   const nextChannel = channels[(index + 1) % channels.length]
-  const next_channel_url = nextChannel
+  const nextChannelUrl = nextChannel
     ? `/channels/${nextChannel.streamId}`
     : null
 
@@ -54,7 +54,7 @@ const ChannelPlayer = (props: Props) => {
           size="small"
           color="primary"
           onClick={() => {
-            history.push(next_channel_url)
+            history.push(nextChannelUrl)
           }}
           style={{ marginRight: '5px' }}
         >

--- a/app/javascript/packs/types/Channel.ts
+++ b/app/javascript/packs/types/Channel.ts
@@ -136,7 +136,7 @@ class Channel {
   }
 
   get compactGenre() {
-    return this.genre.replace(/game[　 ]*/gi, '') // ジャンルの「game」には情報量がないので省略。
+    return this.genre.replace(/(game)*[　 ]*/gi, '') // ジャンルの「game」には情報量がないので省略。
   }
 
   get compactDetails() {
@@ -165,8 +165,8 @@ class Channel {
     const details = this.unescapeHTML(this.detailsLabel) || ''
 
     let text = ''
-    if (this.genre.length) {
-      text = this.genre
+    if (this.compactGenre.length) {
+      text = this.compactGenre
 
       if (text.length && details.length) {
         text += ' - '


### PR DESCRIPTION
ジャンルがスペースだけの時に、ジャンル表示をしないようにした。
```json
  {
    "yellowPage": "SP",
    "name": "ヨーグルト",
    "channelId": "90260C5515192FDC73273FE399D08FC6",
    "tracker": "27.114.47.13:7144",
    "contactUrl": "https://jbbs.shitaraba.net/bbs/read.cgi/netgame/392/1577757928/",
    "genre": "　",
    "description": "おいちゃんの配信 ps4 - <Free>",
    "comment": "",
    "bitrate": 1278,
    "contentType": "WMV",
    "trackTitle": "",
    "album": "",
    "creator": "",
    "trackUrl": "",
    "listeners": 2,
    "relays": 1,
    "uptime": 660
  },
```