### PR TITLE
デフォルトのIP/POSTの場合は、PeerCastの設定を保存しない

### DIFF
--- a/app/javascript/packs/components/SettingDialog.tsx
+++ b/app/javascript/packs/components/SettingDialog.tsx
@@ -49,8 +49,12 @@ const SettingDialog = (props: Props) => {
   const onSaveButtonClick = () => {
     // PeerCastの設定とlocalStorageに保存
     updatePeerCast(dispatch, textHost, textPortNo)
-    localStorage.setItem('pecaHost', textHost)
-    localStorage.setItem('pecaPortNo', textPortNo.toString())
+    if (textHost != PeerCast.defaultHost) {
+      localStorage.setItem('pecaHost', textHost)
+    }
+    if (textPortNo != PeerCast.defaultPortNo) {
+      localStorage.setItem('pecaPortNo', textPortNo.toString())
+    }
   }
 
   const onDefaultButtonClick = () => {


### PR DESCRIPTION
変更前のシュールHOSTのIPが保存されてしまうとやばい。
なので、デフォルトのIPの場合は設定に保存しないように修正。