### PR TITLE
コメント表示の微調整

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::CommentsController < ApplicationController
 
   def fetch_comments
     Rails.cache.fetch("api/v1/comments?url=#{params[:url]}", expires_in: 1.minute) do
-      Bbs.new(params[:url]).fetch_comments
+      Bbs.new(params[:url]).fetch_comments.last(30)
     end
   end
 end

--- a/app/javascript/packs/components/ChannelPlayer.tsx
+++ b/app/javascript/packs/components/ChannelPlayer.tsx
@@ -173,14 +173,13 @@ const ChannelPlayer = (props: Props) => {
               >
                 <div
                   style={{
-                    marginRight: '10px',
-                    width: '36px',
+                    width: '50px',
                     color: 'rgb(0, 128, 0)',
                   }}
                 >
                   {comment['no']}
                 </div>
-                <div>
+                <div style={{ width: '100%' }}>
                   {comment['body'].split('\n').map((line, index) => {
                     return (
                       <div

--- a/lib/bbs.rb
+++ b/lib/bbs.rb
@@ -21,10 +21,14 @@ class Bbs
 
   private
 
+  def parse_web_code(text)
+    text.gsub('&amp;', '&').gsub('&lt;', '<').gsub('&gt;', '>')
+  end
+
   def fetch_shitaraba_comments
     client = HTTPClient.new
     res = client.get(dat_url)
-    dat = res.body
+    dat = parse_web_code(res.body)
     dat.each_line.map do |line|
       elements = line.split('<>')
       { no: elements[0].to_i, name: elements[1], mail: elements[2], writed_at: elements[3], body: elements[4].gsub('<br>', "\n") }
@@ -34,7 +38,7 @@ class Bbs
   def fetch_jpnkn_comments
     client = HTTPClient.new
     res = client.get(dat_url)
-    dat = res.body
+    dat = parse_web_code(res.body)
     dat.each_line.map.with_index(1) do |line, index|
       elements = line.split('<>')
       { no: index, name: elements[0], mail: elements[1], writed_at: elements[2], body: elements[3].gsub('<br>', "\n") }


### PR DESCRIPTION
- HTML文字コードを変換(<>&を表示する)
- コメントは30件だけ表示すれば十分！！
- コメントの本文の開始位置がガタガタになるのを修正