### PR TITLE
視聴者数の非公開に対応

### DIFF
--- a/app/javascript/packs/components/ChannelPlayer.tsx
+++ b/app/javascript/packs/components/ChannelPlayer.tsx
@@ -164,8 +164,8 @@ const ChannelPlayer = (props: Props) => {
               component="p"
               style={{ marginTop: '2px' }}
             >
-              {channel.streamId &&
-                `${channel.listenerCount}人が視聴中 - ${channel.startingTime}から`}
+              {channel.streamId && channel.listenerCount > 0 && `${channel.listenerCount}人が視聴中 - `}
+              {channel.streamId && `${channel.startingTime}から`}
             </Typography>
           </div>
 


### PR DESCRIPTION
リスナー数が-1(非公開)のときは、開始時間のみ表示する。
リスナー数が0の時も非表示にする。
![スクリーンショット_2020-09-26_8_06_06](https://user-images.githubusercontent.com/2564871/94323034-3faf7d00-ffcf-11ea-924d-e470fa236446.png)
