### PR TITLE
コメントAPIで、スレッドタイトルを返す

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::CommentsController < ApplicationController
 
   def fetch_comments
     Rails.cache.fetch("api/v1/bbs/comments?url=#{params[:url]}/v1", expires_in: 10.seconds) do
-      Bbs.new(params[:url]).fetch_comments.reverse.first(30)
+      Bbs.new(params[:url]).fetch_comments
     end
   end
 end

--- a/app/javascript/packs/apis/BbsApi.ts
+++ b/app/javascript/packs/apis/BbsApi.ts
@@ -9,7 +9,8 @@ class BbsApi {
     const response = await fetch(`/api/v1/bbs/comments?url=${this.url}`, {
       credentials: 'same-origin',
     })
-    return (await response.json()) as Array<CommentInterface>
+    const json = await response.json()
+    return json['comments'] as Array<CommentInterface>
   }
 
   // スレッド一覧を取得


### PR DESCRIPTION
```rb
// 20201004074032
// http://0.0.0.0:3000/api/v1/bbs/comments?url=http://bbs.jpnkn.com/test/read.cgi/HebCh/1601615013/

{
  "thread_title": "５７１こめ",
  "comments": [
    {
      "no": 450,
      "name": "名無し＠BBSさん",
      "mail": "sage",
      "writed_at": "2020/10/04(日) 07:10:57.66",
      "body": "ハンドルだー"
    },
    {
      "no": 449,
      "name": "名無し＠BBSさん",
      "mail": "sage",
      "writed_at": "2020/10/04(日) 07:09:55.37",
      "body": "地雷を踏んだら爆発するバグがあるよ"
    },
    {
      "no": 448,
      "name": "名無し＠BBSさん",
      "mail": "sage",
      "writed_at": "2020/10/04(日) 07:07:35.25",
      "body": "拡張工事だー"
    },
...
```