### PR TITLE
音量変更後に、音量を再表示すると常に音量100と表示されていたのを修正

### DIFF
--- a/app/javascript/packs/components/Video.tsx
+++ b/app/javascript/packs/components/Video.tsx
@@ -297,7 +297,7 @@ const Video = (props: Props) => {
                     <Slider
                       color="secondary"
                       orientation="vertical"
-                      defaultValue={100}
+                      defaultValue={player ? player.volume * 100 : 100}
                       valueLabelDisplay="auto"
                       style={{ height: '100px' }}
                       onChange={(event, newValue) => {


### PR DESCRIPTION
下記の場合に常に音量100と表示されていたのを修正
- 音量変更後に、音量スライドーを再表示した時
- 音量変更後に、次の配信に移動した時
![スクリーンショット 2020-10-04 8 10 17](https://user-images.githubusercontent.com/2564871/95003348-685ff400-0619-11eb-9a3e-824bf58da8e3.png)
