### PR TITLE
お気に入りの反映が遅い時があったので、改善！

### DIFF
--- a/app/javascript/packs/app.tsx
+++ b/app/javascript/packs/app.tsx
@@ -70,6 +70,9 @@ const App = () => {
                 Authorization: `Bearer ${idToken}`,
               },
             })
+
+            // ログイン後に「お気に入り」を反映するため、チャンネル情報を再取得する
+            updateChannels(dispatch)
           }
           signinRails()
         })


### PR DESCRIPTION
ログイン後に「お気に入り」を反映するため、チャンネル情報を再取得する