### PR TITLE
したらばのHTML特殊文字を変換（&#65374; → 〜）

### DIFF
--- a/lib/bbs.rb
+++ b/lib/bbs.rb
@@ -198,12 +198,18 @@ class Bbs
   end
 
   def parse_web_code(text)
-    text.gsub('&amp;', '&')
+    result = text.gsub('&amp;', '&')
         .gsub('&lt;', '<')
         .gsub('&gt;', '>')
         .gsub('&quot;', '"')
         .gsub('&#39;', '\'')
         .gsub('&nbsp;', ' ')
+
+    # &#65374; → 〜 に変換
+    result.scan(/&#([0-9]+);/).flatten.each do |char_code|
+      result.gsub!("&##{char_code};", char_code.to_i.chr)
+    end
+    result
   end
 
   def fetch(url, charset_nkf_option)


### PR DESCRIPTION
![スクリーンショット_2020-10-08_6_49_59](https://user-images.githubusercontent.com/2564871/95391741-8c317b80-0932-11eb-8360-87a1e08366e4.png)
