### PR TITLE
対応できないエンコードのエラーは無視する

### DIFF
--- a/lib/bbs.rb
+++ b/lib/bbs.rb
@@ -208,6 +208,8 @@ class Bbs
     # &#65374; → 〜 に変換
     result.scan(/&#([0-9]+);/).flatten.each do |char_code|
       result.gsub!("&##{char_code};", char_code.to_i.chr)
+    rescue Encoding::CompatibilityError
+      # 対応できないエンコードのエラーは無視する
     end
     result
   end


### PR DESCRIPTION
https://app.bugsnag.com/pecalive/pecalive/errors/60272dfb3d01ca0017451e81?filters[event.since][0]=30d&filters[error.status][0]=open