### PR TITLE
存在しないdatを指定された時に落ちないように修正

### DIFF
--- a/lib/bbs.rb
+++ b/lib/bbs.rb
@@ -69,6 +69,7 @@ class Bbs
 
   def fetch_jpnkn_comments
     dat = fetch(dat_url, '-w')
+    return { thread_title: nil, comments: [], comment_count: 0 } if dat.blank?
 
     thread_title = nil
     comments = dat.each_line.map.with_index(1) do |line, index|


### PR DESCRIPTION
↓にアクセスするとエラーになっていた
http://peca.live/api/v1/bbs/comments?url=http://bbs.jpnkn.com/test/read.cgi/ubereats/1612224000/l50

https://app.bugsnag.com/pecalive/pecalive/errors/60271e0cbfb5b9001793806e?filters[event.since][0]=30d&filters[error.status][0]=open