### PR TITLE
PeerCast避難所は海外アクセスを弾いていて、コメントAPIのレスポンスがおかしくなる。空のレスポンスを返すようにした。

### DIFF
--- a/lib/bbs.rb
+++ b/lib/bbs.rb
@@ -219,7 +219,9 @@ class Bbs
     # '-e' -> EUC-JP
     # '-w' -> UTF-8
     client = HTTPClient.new
-    body = client.get(url).body
+    response = client.get(url)
+    return '' if response.status != 200
+    body = response.body
     NKF.nkf(charset_nkf_option, body)
   end
 end


### PR DESCRIPTION
下記のエラーが出て、APIのレスポンスがおかしくなり、React上でエラーが発生する。
```
</body></html>
<address>Apache/2.4.41 (Ubuntu) Server at komokomo.ddns.net Port 80</address>
<hr>
<p>The document has moved <a href=\
http://komokomo.ddns.net:8080/index.html\
>here</a>.</p>
<h1>Found</h1>
</head><body>
<title>302 Found</title>
<html><head>
<!DOCTYPE HTML PUBLIC \
-//IETF//DTD HTML 2.0//EN\
```