### PR TITLE
再生開始時に video 要素の readyState が 3 でもぐるぐるを表示しないようにした。

### DIFF
--- a/app/javascript/packs/components/Video.tsx
+++ b/app/javascript/packs/components/Video.tsx
@@ -176,7 +176,7 @@ const Video = (props: Props) => {
             }}
           />
         ) : (
-          readyState < 4 && (
+          readyState < 3 && (
             <CircularProgress size={80} style={{ color: 'lightgray' }} onClick={() => videoStyleOnClick()} />
           )
         )}


### PR DESCRIPTION
Firefox で再生ページを開くと、配信の再生が始まっても動画プレーヤーの真ん中に読み込み中を表す、ぐるぐる回るアイコンが表示され続けます。

再生開始時に VIDEO 要素の readyState が 4 (HAVE_ENOUGH_DATA) になる Chrome と異なり、Firefox では再生が始まった時の readyState は 3 (HAVE_FUTURE_DATA) で、再生中も 4 には上がらないようです。