### PR TITLE
ページ遷移時に強制リロードする。

### DIFF
--- a/app/javascript/packs/app.tsx
+++ b/app/javascript/packs/app.tsx
@@ -91,7 +91,7 @@ const App = () => {
   }
 
   return (
-    <BrowserRouter>
+    <BrowserRouter forceRefresh={true}>
       <PageViewTracker>
         <div className={classes.root}>
           <CssBaseline />


### PR DESCRIPTION
サイトトップのチャンネルリストから `/チャンネル名` のページに移動したあと、ブラウザの戻るボタンを押すと、真っ白なページが表示されてしまいます。

アプリが壊れてしまう原因はよくわからないのですが、とりあえずBrowserRouterにオプションを渡してページを強制再読み込みさせることでチャンネルリストに戻ることができるようになります。

ただ、チャンネル切り替えが遅くなってしまいますが…。